### PR TITLE
fix: regression to support latest unleash-client (3.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 unleash-client that helps persisting feature toggle results over Express.js
 
+## Prerequisite
+You will need express and [cookie-parser](https://github.com/expressjs/cookie-parser):
+
+```js
+const express = require('express');
+const app = express();
+app.use(cookieParser());
+```
+
 ## Configuration
 
 ```js
@@ -28,11 +37,11 @@ app.use(unleashExpress.middleware()); // This will allow reading/setting the coo
 
 ### 2. Flip the coin
 
-Ask `unleash-client` for the value of a feature as usual by using `experiment`.
+Ask `unleash-client` for the value of a feature as usual by using `getVariant`.
 
 ```js
 // In your feature.controller.js
-req.unleash.experiment('feature', ...);
+req.unleash.getVariant('feature', ...);
 ```
 
 You can also check alternatives or features that are enabled by using `isEnabled`.

--- a/lib/unleash-express.js
+++ b/lib/unleash-express.js
@@ -19,12 +19,12 @@ class UnleashExpress {
         const self = this;
         return function unleashExpress(req, res, next) {
             const cookieStore = new ExpressCookieStore(req, res, options);
-            const results = new Results(self.client.getToggles(), cookieStore);
-            const wrappedExperiment = getWrappedClientFunction.call(self, 'experiment', results);
+            const results = new Results(self.client.getFeatureToggleDefinitions(), cookieStore);
+            const wrappedGetVariant = getWrappedClientFunction.call(self, 'getVariant', results);
             const wrappedIsEnabled = getWrappedClientFunction.call(self, 'isEnabled', results);
 
             req.unleash = {
-                experiment: wrappedExperiment,
+                getVariant: wrappedGetVariant,
                 isEnabled: wrappedIsEnabled,
                 results,
             };

--- a/lib/unleash-express.test.js
+++ b/lib/unleash-express.test.js
@@ -56,7 +56,7 @@ test('should use the experiment result', t => {
     const unleashExpress = new UnleashExpress(unleash);
     app.use(unleashExpress.middleware());
     app.use(req => {
-        req.unleash.experiment('feature.variants.A');
+        req.unleash.getVariant('feature.variants.A');
         t.true(req.unleash.results.get('feature.variants.A').name === 'control');
     });
 });
@@ -75,9 +75,9 @@ test('should use the persisted experiment result across multiple experiment call
     const unleashExpress = new UnleashExpress(unleash);
     app.use(unleashExpress.middleware());
     app.use(req => {
-        t.true(req.unleash.experiment('feature.variants.A').name === 'control');
+        t.true(req.unleash.getVariant('feature.variants.A').name === 'control');
         t.true(req.unleash.results.get('feature.variants.A').name === 'control');
-        t.true(req.unleash.experiment('feature.variants.A').name === 'control');
+        t.true(req.unleash.getVariant('feature.variants.A').name === 'control');
         t.true(req.unleash.results.get('feature.variants.A').name === 'control');
     });
 });
@@ -117,6 +117,6 @@ test('should override the result of an experiment even if persisted', t => {
     const unleashExpress = new UnleashExpress(unleash);
     app.use(unleashExpress.middleware());
     app.use(req => {
-        t.true(typeof req.unleash.experiment('feature.variants.A') === 'undefined');
+        t.true(typeof req.unleash.getVariant('feature.variants.A') === 'undefined');
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unleash-express",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "express helper for unleash",
   "main": "lib/unleash-express.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "supertest": "^3.0.0"
   },
   "peerDependencies": {
-    "unleash-client": "^3.2.0"
+    "unleash-client": "^3.2.8get"
   },
   "repository": "https://github.com/Unleash/unleash-express",
   "private": false,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,11 +8,11 @@ class Unleash {
         this.features = features;
     }
 
-    getToggles() {
+    getFeatureToggleDefinitions() {
         return this.features;
     }
 
-    experiment(name) {
+    getVariant(name) {
         const features = this.features.features;
         const feature = features.find(f => f.name === name && f.enabled === true);
         let variant;

--- a/test/unleash-express.e2e.test.js
+++ b/test/unleash-express.e2e.test.js
@@ -19,7 +19,7 @@ test('should return the persisted results across requests of the same client', a
     const request = _request.agent(app); // persist cookies via an agent, simulating the same client
 
     app.get('/', (req, res) => {
-        res.send(req.unleash.experiment('feature.variants.A').name);
+        res.send(req.unleash.getVariant('feature.variants.A').name);
     });
 
     await request
@@ -57,7 +57,7 @@ test('should return different persisted results across requests from different c
     const request = _request(app); // no cookies will be persisted, simulating different clients
 
     app.get('/', (req, res) => {
-        res.send(req.unleash.experiment('feature.variants.A').name);
+        res.send(req.unleash.getVariant('feature.variants.A').name);
     });
 
     await request
@@ -110,7 +110,7 @@ test('should remove the state of a feature from the cookie if not enabled', asyn
         .expect('set-cookie', `unleash=${cookieValue({})}; Path=/`);
 });
 
-test('should remove the state of an experiment from the cookie if no variant was returned', async t => {
+test('should remove the state of an getVariant from the cookie if no variant was returned', async t => {
     t.plan(0);
     const unleash = new Unleash({
         features: [
@@ -126,7 +126,7 @@ test('should remove the state of an experiment from the cookie if no variant was
     const request = _request.agent(app); // persist cookies via an agent, simulating the same client
 
     app.get('/', (req, res) => {
-        res.send(req.unleash.experiment('feature.variants.A'));
+        res.send(req.unleash.getVariant('feature.variants.A'));
     });
 
     await request


### PR DESCRIPTION
I'm not fully sure when this broke, but probably as part of variants becoming official part of the node client. 

Renamed the following:
experiements => getVariant
getToggles => getFeatureToggleDefinitions